### PR TITLE
Moved opts.marked to a right place.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = require('postcss').plugin('mdcss', function (opts) {
 
 					// remove meta from documentation content
 					return '';
-				}, opts.marked).trim();
+				}).trim();
 
 				// conditionally set the closest documentation name
 				if (doc.title && !doc.name) doc.name = titleToName(doc.title);
@@ -104,7 +104,7 @@ module.exports = require('postcss').plugin('mdcss', function (opts) {
 					}
 				}
 
-				doc.content = marked(doc.content);
+				doc.content = marked(doc.content, opts.marked);
 
 				// set documentation context
 				doc.context = comment;


### PR DESCRIPTION
Opts.marked was provided as a third parameter of string replace. Small typo in a previous versions (opts.marked in wrong parentheses), in a current one call to marked changed its location. That wasn't working all along. After fix i can provide my custom markdown renderer straight from my gulpfile.
